### PR TITLE
Update README to include 'make' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### Build provider files:
 1. Update config.json
-1. Run `make dist`
+1. Run `make` then `make dist`
 
     1. offline/dist.tgz will be created
 


### PR DESCRIPTION
I found some things weren't building properly unless I did a `make` before the `make dist`.

Sorry, a better pull request would have been if I found the root cause and fixed the dependencies in the Makefile. But, this might help some people until then.