### PR TITLE
update docker compose file to versi 3.4.2

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -1,5 +1,5 @@
-PUBLIC_IP=192.168.56.108
+PUBLIC_IP=10.168.12.3
 SECRET=secret
 RETHINKDB_PORT_28015_TCP=tcp://rethinkdb:28015
 HOSTNAME=stf.test
-STF_IMAGE=openstf/stf:v3.4.1
+STF_IMAGE=openstf/stf:v3.4.2

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -54,7 +54,11 @@ services:
     restart: unless-stopped
     environment:
       - SECRET
+      - RETHINKDB_PORT_28015_TCP
     command: stf auth-mock --app-url http://${HOSTNAME}/ --port 3000
+    depends_on:
+      - rethinkdb
+      - triproxy
   processor:
     image: ${STF_IMAGE}
     restart: unless-stopped
@@ -173,6 +177,8 @@ services:
       --port 3000
       --connect-sub tcp://triproxy:7150
       --connect-push tcp://triproxy:7170
+      --connect-sub-dev tcp://triproxy:7150
+      --connect-push-dev tcp://triproxy:7170
     ports:
       - 10001:9229
     volumes:


### PR DESCRIPTION
hi i am try docker to run image openstf/stf:v3.4.2 failed, so i update  docker-compose.yml to running versi image openstf/stf:v3.4.2. 

please check it